### PR TITLE
Debug expo-sqlite web assembly resolution

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,8 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+// Ensure WebAssembly modules are treated as assets so they can be resolved on web
+config.resolver.assetExts = [...config.resolver.assetExts, 'wasm'];
+
+module.exports = config;


### PR DESCRIPTION
Add Metro config to resolve `.wasm` files as assets, fixing `expo-sqlite` web bundling.

---
<a href="https://cursor.com/background-agent?bcId=bc-73fd4f24-18cb-4176-9435-0382b080079a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-73fd4f24-18cb-4176-9435-0382b080079a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

